### PR TITLE
Added Focus mode

### DIFF
--- a/src/components/EpisodeGrid.js
+++ b/src/components/EpisodeGrid.js
@@ -1,60 +1,49 @@
 import React from 'react';
-import { motion } from 'framer-motion';
 
 const EpisodeGrid = ({ type, mediaData, episodes, seasons, currentEpisode, handleInputChange }) => {
   if (type !== 'tv') return null;
 
-  const episodeItemClasses = (episode) => `
-    relative p-4 rounded-lg transition-all duration-200 cursor-pointer
-    ${currentEpisode?.id === episode.id 
-      ? 'bg-[#02c39a]/20 dark:bg-[#00edb8]/20 ring-2 ring-[#02c39a] dark:ring-[#00edb8] shadow-lg' 
-      : 'hover:bg-white/10 dark:hover:bg-gray-800/60'}
-    ${episode.still_path 
-      ? 'hover:scale-105 active:scale-95' 
-      : 'opacity-50'}
-  `;
-
   return (
-    <div className="space-y-6">
-      {/* Season selector */}
-      <div className="flex items-center gap-4">
-        <label className="text-lg font-semibold">Season:</label>
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-2">
         <select
-          name="season"
           value={mediaData.season}
-          onChange={handleInputChange}
-          className="bg-white/10 dark:bg-gray-800/40 rounded-lg px-4 py-2 outline-none 
-            focus:ring-2 ring-[#02c39a] dark:ring-[#00edb8] backdrop-blur-sm
-            border border-gray-200/20 hover:bg-white/20 dark:hover:bg-gray-800/60
-            transition-all duration-200"
+          onChange={(e) => handleInputChange({
+            target: { name: 'season', value: e.target.value }
+          })}
+          className="bg-transparent text-white/90 text-sm sm:text-base font-medium 
+            outline-none cursor-pointer hover:text-[#02c39a] transition-colors
+            py-1.5 px-2 sm:px-3 rounded-md touch-manipulation min-h-[40px]"
         >
           {seasons.map((season) => (
-            <option key={season.season_number} value={season.season_number}>
+            <option 
+              key={season.season_number}
+              value={season.season_number}
+              className="bg-[#1a2634] text-white py-2"
+            >
               Season {season.season_number}
             </option>
           ))}
         </select>
       </div>
 
-      {/* Episodes grid */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+      <div className="grid grid-cols-2 xs:grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 gap-3">
         {episodes.map((episode) => (
-          <motion.div
+          <button
             key={episode.id}
-            layoutId={`episode-${episode.id}`}
-            className={episodeItemClasses(episode)}
+            className={`relative group ${
+              currentEpisode?.id === episode.id ? 'ring-2 ring-[#02c39a]' : ''
+            } rounded-lg overflow-hidden bg-white/5 hover:bg-white/10 transition-colors`}
             onClick={() => handleInputChange({
               target: { name: 'episodeNo', value: episode.episode_number.toString() }
             })}
           >
-            {/* Episode thumbnail */}
-            <div className="relative aspect-video rounded-lg overflow-hidden mb-3 
-              bg-gray-900/40 backdrop-blur-sm">
+            <div className="relative aspect-video rounded-lg overflow-hidden bg-gray-900/40 backdrop-blur-sm">
               {episode.still_path ? (
                 <img
                   src={`https://image.tmdb.org/t/p/w300${episode.still_path}`}
                   alt={episode.name}
-                  className="w-full h-full object-cover"
+                  className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
                   loading="lazy"
                 />
               ) : (
@@ -62,38 +51,32 @@ const EpisodeGrid = ({ type, mediaData, episodes, seasons, currentEpisode, handl
                   <span className="text-gray-400">No Preview</span>
                 </div>
               )}
-              {/* Current episode indicator */}
+              
               {currentEpisode?.id === episode.id && (
                 <div className="absolute top-2 right-2 flex items-center gap-2 
                   bg-[#02c39a] dark:bg-[#00edb8] px-3 py-1 rounded-full shadow-lg">
                   <div className="w-2 h-2 bg-white rounded-full animate-pulse" />
-                  <span className="text-xs font-medium">Playing</span>
+                  <span className="text-xs text-black font-medium">Playing</span>
                 </div>
               )}
-              <div className="absolute bottom-0 left-0 right-0 p-2 
-                bg-gradient-to-t from-black/80 to-transparent">
-                <span className="text-sm font-medium text-white">
-                  Episode {episode.episode_number}
-                </span>
-              </div>
             </div>
 
-            {/* Episode info */}
-            <div className="space-y-2">
-              <h3 className="font-semibold line-clamp-1 group-hover:text-[#02c39a] 
-                dark:group-hover:text-[#00edb8] transition-colors">
+            <div className="p-2 space-y-1">
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-white/60 font-medium">
+                  Episode {episode.episode_number}
+                </span>
+                {episode.vote_average > 0 && (
+                  <span className="text-xs bg-yellow-500/20 text-yellow-500 px-1.5 py-0.5 rounded">
+                    {episode.vote_average.toFixed(1)}
+                  </span>
+                )}
+              </div>
+              <h3 className="text-sm font-medium text-white/90 line-clamp-2 group-hover:text-[#02c39a] transition-colors">
                 {episode.name}
               </h3>
-              <p className="text-sm text-gray-400 dark:text-gray-300 line-clamp-2">
-                {episode.overview || 'No description available.'}
-              </p>
-              {episode.air_date && (
-                <p className="text-xs text-gray-500 dark:text-gray-400">
-                  Aired: {new Date(episode.air_date).toLocaleDateString()}
-                </p>
-              )}
             </div>
-          </motion.div>
+          </button>
         ))}
       </div>
     </div>

--- a/src/components/EpisodeNavigation.js
+++ b/src/components/EpisodeNavigation.js
@@ -27,72 +27,66 @@ const EpisodeNavigation = ({
   if (!episodes.length || !currentEpisode) return null;
 
   return (
-    <div className={`flex items-center justify-between gap-2 mt-4 p-3 rounded-lg ${
+    <div className={`flex flex-col sm:flex-row items-stretch sm:items-center justify-between gap-2 sm:gap-4 p-2 sm:p-3 rounded-lg ${
       isDarkMode ? 'bg-gray-800' : 'bg-gray-100'
     }`}>
       <motion.button
         onClick={handlePrevious}
         disabled={!hasPrevious || isLoading}
-        className={`flex items-center gap-1 px-3 py-2 rounded-lg transition-colors ${
+        className={`flex-1 sm:flex-initial flex items-center justify-center gap-1 px-3 py-2 rounded-lg transition-all duration-200 ${
           isDarkMode
             ? 'text-white hover:bg-gray-700 disabled:opacity-40 disabled:hover:bg-transparent'
             : 'text-gray-800 hover:bg-gray-200 disabled:opacity-40 disabled:hover:bg-transparent'
         }`}
-        whileHover={hasPrevious && !isLoading ? { scale: 1.05 } : {}}
-        whileTap={hasPrevious && !isLoading ? { scale: 0.95 } : {}}
+        whileHover={hasPrevious && !isLoading ? { scale: 1.02 } : {}}
+        whileTap={hasPrevious && !isLoading ? { scale: 0.98 } : {}}
         data-tooltip-id="prev-tooltip"
         data-tooltip-content={hasPrevious ?
           `S${season} E${episodes[currentEpisodeIndex - 1]?.episode_number}: ${episodes[currentEpisodeIndex - 1]?.name}` :
           'First episode'}
       >
-        <ChevronLeftIcon className="w-6 h-6 sm:h-5 sm:w-5" />
-        <span className="hidden sm:inline">Prev</span>
-        <span className="hidden md:inline"> Episode</span>
+        <ChevronLeftIcon className="w-5 h-5" />
+        <span className="whitespace-nowrap">Previous</span>
       </motion.button>
 
       <AnimatePresence mode="wait">
-        <motion.div
-          key={`s${season}e${currentEpisodeNo}`}
-          initial={{ opacity: 0, y: -5 }}
-          animate={{ opacity: 1, y: 0 }}
-          exit={{ opacity: 0, y: 5 }}
-          className="flex items-center gap-2 text-sm md:text-base"
-        >
-          {isLoading ? (
-            <div className="h-4 w-24 bg-gray-400/20 rounded animate-pulse" />
-          ) : (
-            <>
-              <span className="sm:hidden">E{currentEpisodeNo}</span>
-              <span className="hidden sm:inline md:hidden">Ep. {currentEpisodeNo}</span>
-              <span className="hidden md:inline">
-                S{season} E{currentEpisodeNo}:{' '}
-                <span className="text-gray-500 dark:text-gray-400">
-                  {currentEpisode.name}
-                </span>
+        {currentEpisode && (
+          <motion.div
+            key={currentEpisode.id}
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -20 }}
+            className="flex-1 min-w-0 px-3 py-2 text-center"
+          >
+            <span className="flex flex-col sm:flex-row items-center justify-center gap-1 sm:gap-2">
+              <span className="font-medium">
+                S{season} E{currentEpisode.episode_number}
               </span>
-            </>
-          )}
-        </motion.div>
+              <span className="text-gray-500 dark:text-gray-400 truncate text-sm">
+                {currentEpisode.name}
+              </span>
+            </span>
+          </motion.div>
+        )}
       </AnimatePresence>
 
       <motion.button
         onClick={handleNext}
         disabled={!hasNext || isLoading}
-        className={`flex items-center gap-1 px-3 py-2 rounded-lg transition-colors ${
+        className={`flex-1 sm:flex-initial flex items-center justify-center gap-1 px-3 py-2 rounded-lg transition-all duration-200 ${
           isDarkMode
             ? 'text-white hover:bg-gray-700 disabled:opacity-40 disabled:hover:bg-transparent'
             : 'text-gray-800 hover:bg-gray-200 disabled:opacity-40 disabled:hover:bg-transparent'
         }`}
-        whileHover={hasNext && !isLoading ? { scale: 1.05 } : {}}
-        whileTap={hasNext && !isLoading ? { scale: 0.95 } : {}}
+        whileHover={hasNext && !isLoading ? { scale: 1.02 } : {}}
+        whileTap={hasNext && !isLoading ? { scale: 0.98 } : {}}
         data-tooltip-id="next-tooltip"
         data-tooltip-content={hasNext ?
           `S${season} E${episodes[currentEpisodeIndex + 1]?.episode_number}: ${episodes[currentEpisodeIndex + 1]?.name}` :
           'Next episode coming soon'}
       >
-        <span className="hidden sm:inline">Next</span>
-        <span className="hidden md:inline"> Episode</span>
-        <ChevronRightIcon className="w-6 h-6 sm:h-5 sm:w-5" />
+        <span className="whitespace-nowrap">Next</span>
+        <ChevronRightIcon className="w-5 h-5" />
       </motion.button>
 
       <Tooltip id="prev-tooltip" className="max-w-xs z-[100]" />

--- a/src/components/SourceSelector.js
+++ b/src/components/SourceSelector.js
@@ -30,51 +30,60 @@ const SourceSelector = ({ videoSource, handleSourceChange, showSourceMenu, setSh
     }, [showSourceMenu, handleClickOutside]); // Dependency includes handleClickOutside
 
     return (
-        <div className="mb-4">
-            <div className="relative">
-                <button
-                    ref={buttonRef}
-                    onClick={() => setShowSourceMenu(!showSourceMenu)}
-                    className="w-full bg-white dark:bg-gray-800 px-4 py-2 rounded-lg flex items-center justify-between shadow-sm border border-gray-200 dark:border-gray-700"
-                    aria-label="Select video source"
-                >
-                    <span className="flex items-center gap-2">
-                        <svg className="w-5 h-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
-                        </svg>
-                        {VIDEO_SOURCES[videoSource]?.name}
-                        <span className="text-xs text-gray-500 dark:text-gray-400">
+        <div className="relative w-full">
+            <button
+                ref={buttonRef}
+                onClick={() => setShowSourceMenu(!showSourceMenu)}
+                className="w-full bg-white/5 dark:bg-gray-800/30 px-3 py-2 rounded-lg flex items-center justify-between 
+                    border border-white/10 dark:border-gray-700/30 hover:bg-white/10 dark:hover:bg-gray-700/50 
+                    transition-colors duration-200"
+                aria-label="Select video source"
+            >
+                <span className="flex items-center gap-2 truncate">
+                    <svg className="w-5 h-5 text-white/60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                    </svg>
+                    <span className="flex items-center gap-1 truncate text-white/90">
+                        <span className="truncate">{VIDEO_SOURCES[videoSource]?.name}</span>
+                        <span className="text-xs text-white/60 whitespace-nowrap">
                             ({VIDEO_SOURCES[videoSource]?.quality})
                         </span>
                     </span>
-                    <svg className={`w-5 h-5 ${showSourceMenu ? 'transform rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                    </svg>
-                </button>
+                </span>
+                <svg className={`w-5 h-5 text-white/60 flex-shrink-0 transition-transform duration-200 ${showSourceMenu ? 'rotate-180' : ''}`} 
+                    fill="none" stroke="currentColor" viewBox="0 0 24 24"
+                >
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+            </button>
 
-                {showSourceMenu && (
-                    <div ref={dropdownRef} className="absolute mt-2 w-full rounded-lg bg-white dark:bg-gray-800 shadow-lg z-50" role="menu">
-                        {Object.entries(VIDEO_SOURCES).map(([key, { name, quality }]) => (
-                            <button
-                                key={key}
-                                onClick={() => {
-                                    handleSourceChange(key);
-                                    setShowSourceMenu(false);
-                                }}
-                                onKeyDown={(event) => handleKeyDown(event, key)}
-                                className="w-full px-4 py-2 text-left hover:bg-gray-100 dark:hover:bg-gray-700 flex justify-between items-center"
-                                role="menuitem"
-                                tabIndex="0"
-                            >
-                                <span>{name}</span>
-                                <span className="text-xs text-gray-500">{quality}</span>
-                            </button>
-                        ))}
-                    </div>
-                )}
-                {showSourceMenu && (<div className="absolute inset-0 bg-black bg-opacity-50 z-40 md:hidden" />)}
-
-            </div>
+            {showSourceMenu && (
+                <div 
+                    ref={dropdownRef} 
+                    className="absolute mt-2 w-full rounded-lg bg-white/10 dark:bg-gray-800/90 backdrop-blur-md 
+                        shadow-lg border border-white/10 dark:border-gray-700/30 z-50 max-h-[50vh] overflow-y-auto" 
+                    role="menu"
+                >
+                    {Object.entries(VIDEO_SOURCES).map(([key, { name, quality }]) => (
+                        <button
+                            key={key}
+                            onClick={() => {
+                                handleSourceChange(key);
+                                setShowSourceMenu(false);
+                            }}
+                            onKeyDown={(event) => handleKeyDown(event, key)}
+                            className="w-full px-4 py-3 text-left hover:bg-white/10 dark:hover:bg-gray-700/50 
+                                flex justify-between items-center text-white/90 transition-colors duration-200
+                                border-b border-white/5 dark:border-gray-700/30 last:border-0"
+                            role="menuitem"
+                            tabIndex="0"
+                        >
+                            <span className="truncate pr-2">{name}</span>
+                            <span className="text-xs text-white/60 whitespace-nowrap">{quality}</span>
+                        </button>
+                    ))}
+                </div>
+            )}
         </div>
     );
 };

--- a/src/components/WatchPage.js
+++ b/src/components/WatchPage.js
@@ -69,6 +69,7 @@ const WatchPage = () => {
   const [showBackgroundPoster, setShowBackgroundPoster] = useState(false);
   const [isLowEndDevice, setIsLowEndDevice] = useState(false);
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const [isDistractFree, setIsDistractFree] = useState(false);
 
   const buttonClasses = {
     base: `flex items-center gap-1.5 sm:gap-2 xs:gap-1 p-3 sm:p-4 xs:p-2 rounded-full shadow-lg transition-all duration-300
@@ -561,18 +562,26 @@ const WatchPage = () => {
           >
             <div className="flex flex-col lg:flex-row gap-3 sm:gap-4 lg:gap-8">
               {/* Main content column */}
-              <div className="lg:w-2/3 flex flex-col space-y-4">
+              <div className={`${isDistractFree ? 'w-full' : 'lg:w-2/3'} flex flex-col space-y-4`}>
                 {/* Title and tagline */}
-                <div className="flex flex-col gap-4 mb-6">
-                  <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-white/90">
-                    {item?.title || item?.name}
-                  </h1>
-                  {item?.tagline && (
-                    <p className="text-lg sm:text-xl text-white/70 italic">
-                      {item.tagline}
-                    </p>
+                <AnimatePresence>
+                  {!isDistractFree && (
+                    <motion.div 
+                      initial={{ opacity: 1, height: 'auto' }}
+                      exit={{ opacity: 0, height: 0 }}
+                      className="flex flex-col gap-4 mb-6"
+                    >
+                      <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-white/90">
+                        {item?.title || item?.name}
+                      </h1>
+                      {item?.tagline && (
+                        <p className="text-lg sm:text-xl text-white/70 italic">
+                          {item.tagline}
+                        </p>
+                      )}
+                    </motion.div>
                   )}
-                </div>
+                </AnimatePresence>
 
                 {/* Video Player */}
                 <motion.div 
@@ -614,30 +623,54 @@ const WatchPage = () => {
                 >
                   <div className="flex flex-wrap items-center justify-between gap-2 sm:gap-3 bg-black/40 
                     backdrop-blur-sm rounded-lg p-2 sm:p-3 border border-white/10">
-                    <div className="flex items-center gap-2 sm:gap-3 flex-1 min-w-[120px] sm:min-w-[140px]">
-                      <SourceSelector
-                        videoSource={videoSource}
-                        handleSourceChange={handleSourceChange}
-                        showSourceMenu={showSourceMenu}
-                        setShowSourceMenu={setShowSourceMenu}
-                      />
-                      <a
-                        href={type === 'movie' 
-                          ? `https://dl.vidsrc.vip/movie/${id}`
-                          : `https://dl.vidsrc.vip/tv/${id}/${mediaData.season}/${mediaData.episodeNo}`
-                        }
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="flex items-center gap-2 px-3 sm:px-4 py-2 sm:py-3 bg-white/5 rounded-lg 
-                          text-white/60 hover:text-white/90 transition-colors text-sm sm:text-base 
-                          active:scale-95 transform hover:scale-105"
-                      >
-                        <svg className="w-5 h-5 sm:w-6 sm:h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} 
-                            d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                        </svg>
-                        <span>Download</span>
-                      </a>
+                    <div className="flex flex-wrap items-center gap-2 sm:gap-3 w-full sm:w-auto">
+                      <div className="w-full sm:w-auto min-w-[120px]">
+                        <SourceSelector
+                          videoSource={videoSource}
+                          handleSourceChange={handleSourceChange}
+                          showSourceMenu={showSourceMenu}
+                          setShowSourceMenu={setShowSourceMenu}
+                        />
+                      </div>
+                      <div className="flex items-center gap-2 w-full sm:w-auto">
+                        <a
+                          href={type === 'movie' 
+                            ? `https://dl.vidsrc.vip/movie/${id}`
+                            : `https://dl.vidsrc.vip/tv/${id}/${mediaData.season}/${mediaData.episodeNo}`
+                          }
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex-1 sm:flex-none flex items-center justify-center gap-2 px-3 sm:px-4 py-2 sm:py-3 bg-white/5 rounded-lg 
+                            text-white/60 hover:text-white/90 transition-colors text-sm sm:text-base 
+                            active:scale-95 transform hover:scale-105"
+                        >
+                          <svg className="w-5 h-5 sm:w-6 sm:h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} 
+                              d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                          </svg>
+                          <span>Download</span>
+                        </a>
+                        <button
+                          onClick={() => setIsDistractFree(prev => !prev)}
+                          className={`flex-1 sm:flex-none flex items-center justify-center gap-2 px-3 sm:px-4 py-2 sm:py-3 rounded-lg 
+                            transition-colors text-sm sm:text-base active:scale-95 transform hover:scale-105
+                            ${isDistractFree ? 
+                              'bg-[#02c39a] text-white hover:bg-[#00a896]' : 
+                              'bg-white/5 text-white/60 hover:text-white/90'}`}
+                          aria-label={isDistractFree ? "Exit distraction-free mode" : "Enter distraction-free mode"}
+                        >
+                          <svg className="w-5 h-5 sm:w-6 sm:h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} 
+                              d={isDistractFree ?
+                                "M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V9a2 2 0 012-2h2a2 2 0 012 2v10a2 2 0 01-2 2h-2a2 2 0 01-2-2z" :
+                                "M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zm0 8a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1v-2z"} 
+                            />
+                          </svg>
+                          <span className="hidden sm:inline">
+                            {isDistractFree ? "Exit Focus" : "Focus Mode"}
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </motion.div>
@@ -772,201 +805,217 @@ const WatchPage = () => {
                 </Suspense>
 
                 {/* Content tabs */}
-                <Suspense fallback={<div className="h-96 bg-gray-800/40 animate-pulse rounded-lg" />}>
-                  {item && (
-                    <motion.div
-                      variants={itemVariants}
-                      className={`mt-3 sm:mt-6 ${isDarkMode ? 'bg-white dark:bg-[#1a2634]' : `${lightModeStyles.cardBg} ${lightModeStyles.cardBorder}`} rounded-lg sm:rounded-xl 
-                        shadow-md sm:shadow-lg dark:shadow-black/50 p-3 sm:p-6`}
-                      whileHover={{ scale: 1.005 }}
-                      transition={{ type: "spring", stiffness: 300 }}
-                    >
-                      <ContentTabs
-                        item={item}
-                        detailedOverview={detailedOverview}
-                        showFullOverview={showFullOverview}
-                        setShowFullOverview={setShowFullOverview}
-                        cast={cast}
-                        crew={crew}
-                        reviews={reviews}
-                        similar={similar}
-                        handleListItemClick={handleListItemClick}
-                      />
-                    </motion.div>
+                <AnimatePresence>
+                  {!isDistractFree && (
+                    <Suspense fallback={<div className="h-96 bg-gray-800/40 animate-pulse rounded-lg" />}>
+                      {item && (
+                        <motion.div
+                          initial={{ opacity: 1, height: 'auto' }}
+                          exit={{ opacity: 0, height: 0 }}
+                          variants={itemVariants}
+                          className={`mt-3 sm:mt-6 ${isDarkMode ? 'bg-white dark:bg-[#1a2634]' : `${lightModeStyles.cardBg} ${lightModeStyles.cardBorder}`} rounded-lg sm:rounded-xl 
+                            shadow-md sm:shadow-lg dark:shadow-black/50 p-3 sm:p-6`}
+                        >
+                          <ContentTabs
+                            item={item}
+                            detailedOverview={detailedOverview}
+                            showFullOverview={showFullOverview}
+                            setShowFullOverview={setShowFullOverview}
+                            cast={cast}
+                            crew={crew}
+                            reviews={reviews}
+                            similar={similar}
+                            handleListItemClick={handleListItemClick}
+                          />
+                        </motion.div>
+                      )}
+                    </Suspense>
                   )}
-                </Suspense>
+                </AnimatePresence>
               </div>
 
               {/* Recommendations column */}
-              <div className="lg:w-1/3">
-                <Suspense fallback={<div className="h-96 bg-gray-800/40 animate-pulse rounded-lg" />}>
+              <AnimatePresence>
+                {!isDistractFree && (
                   <motion.div 
-                    className="sticky top-6 space-y-6"
-                    initial={{ opacity: 0, y: 20 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ delay: 0.4 }}
+                    initial={{ opacity: 1, width: 'auto' }}
+                    exit={{ opacity: 0, width: 0 }}
+                    className="lg:w-1/3"
                   >
-                    {/* Desktop Recommendations */}
-                    <div className="hidden lg:block">
-                      <div className="bg-black/40 backdrop-blur-sm rounded-xl border border-white/10 overflow-hidden shadow-lg">
-                        <div className="p-4 border-b border-white/10">
-                          <h2 className="text-xl font-semibold text-white/90">Recommended For You</h2>
+                    <Suspense fallback={<div className="h-96 bg-gray-800/40 animate-pulse rounded-lg" />}>
+                      <motion.div 
+                        className="sticky top-6 space-y-6"
+                        initial={{ opacity: 0, y: 20 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        transition={{ delay: 0.4 }}
+                      >
+                        {/* Desktop Recommendations */}
+                        <div className="hidden lg:block">
+                          <div className="bg-black/40 backdrop-blur-sm rounded-xl border border-white/10 overflow-hidden shadow-lg">
+                            <div className="p-4 border-b border-white/10">
+                              <h2 className="text-xl font-semibold text-white/90">Recommended For You</h2>
+                            </div>
+                            <div className="p-4">
+                              <Recommendations
+                                recommendations={recommendations}
+                                handleListItemClick={handleListItemClick}
+                              />
+                            </div>
+                          </div>
                         </div>
-                        <div className="p-4">
-                          <Recommendations
-                            recommendations={recommendations}
-                            handleListItemClick={handleListItemClick}
-                          />
-                        </div>
-                      </div>
-                    </div>
 
-                    {/* Mobile Recommendations */}
-                    <div className="block lg:hidden">
-                      <div className="space-y-4">
-                        <div className="flex items-center justify-between px-2">
-                          <h2 className="text-xl font-semibold text-white/90">Recommended For You</h2>
-                          <motion.button 
-                            whileHover={{ scale: 1.05 }}
-                            whileTap={{ scale: 0.95 }}
-                            className="p-2 rounded-lg bg-[#02c39a]/10 text-[#02c39a] hover:bg-[#02c39a]/20 transition-colors"
-                          >
-                            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                            </svg>
-                          </motion.button>
-                        </div>
-                        <motion.div 
-                          className="grid grid-cols-2 xs:grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-3 bg-black/40 
-                            backdrop-blur-sm rounded-xl border border-white/10 p-4"
-                          initial={{ opacity: 0, y: 20 }}
-                          animate={{ opacity: 1, y: 0 }}
-                          transition={{ staggerChildren: 0.1 }}
-                        >
-                          {recommendations.slice(0, 6).map((item, index) => (
-                            <motion.div
-                              key={item.id}
-                              className="group relative flex flex-col gap-2 cursor-pointer"
-                              onClick={() => handleListItemClick(item)}
+                        {/* Mobile Recommendations */}
+                        <div className="block lg:hidden">
+                          <div className="space-y-4">
+                            <div className="flex items-center justify-between px-2">
+                              <h2 className="text-xl font-semibold text-white/90">Recommended For You</h2>
+                              <motion.button 
+                                whileHover={{ scale: 1.05 }}
+                                whileTap={{ scale: 0.95 }}
+                                className="p-2 rounded-lg bg-[#02c39a]/10 text-[#02c39a] hover:bg-[#02c39a]/20 transition-colors"
+                              >
+                                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                                </svg>
+                              </motion.button>
+                            </div>
+                            <motion.div 
+                              className="grid grid-cols-2 xs:grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-3 bg-black/40 
+                                backdrop-blur-sm rounded-xl border border-white/10 p-4"
                               initial={{ opacity: 0, y: 20 }}
                               animate={{ opacity: 1, y: 0 }}
-                              transition={{ delay: index * 0.1 }}
-                              whileHover={{ scale: 1.05 }}
+                              transition={{ staggerChildren: 0.1 }}
                             >
-                              <div className="relative aspect-[2/3] rounded-lg overflow-hidden shadow-lg group-hover:shadow-xl transition-shadow duration-300">
-                                <img
-                                  src={`https://image.tmdb.org/t/p/w300${item.poster_path}`}
-                                  data-src={`https://image.tmdb.org/t/p/w500${item.poster_path}`}
-                                  alt={item.title || item.name}
-                                  className="w-full h-full object-cover transform group-hover:scale-110 transition-transform duration-300"
-                                  loading="lazy"
-                                  onError={(e) => { e.target.src = '/fallback-poster.jpg' }}
-                                />
-                                <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                                  <div className="absolute bottom-0 left-0 right-0 p-2">
-                                    <p className="text-xs text-white/90 text-center line-clamp-2">
-                                      {item.overview?.slice(0, 50)}...
-                                    </p>
+                              {recommendations.slice(0, 6).map((item, index) => (
+                                <motion.div
+                                  key={item.id}
+                                  className="group relative flex flex-col gap-2 cursor-pointer"
+                                  onClick={() => handleListItemClick(item)}
+                                  initial={{ opacity: 0, y: 20 }}
+                                  animate={{ opacity: 1, y: 0 }}
+                                  transition={{ delay: index * 0.1 }}
+                                  whileHover={{ scale: 1.05 }}
+                                >
+                                  <div className="relative aspect-[2/3] rounded-lg overflow-hidden shadow-lg group-hover:shadow-xl transition-shadow duration-300">
+                                    <img
+                                      src={`https://image.tmdb.org/t/p/w300${item.poster_path}`}
+                                      data-src={`https://image.tmdb.org/t/p/w500${item.poster_path}`}
+                                      alt={item.title || item.name}
+                                      className="w-full h-full object-cover transform group-hover:scale-110 transition-transform duration-300"
+                                      loading="lazy"
+                                      onError={(e) => { e.target.src = '/fallback-poster.jpg' }}
+                                    />
+                                    <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                                      <div className="absolute bottom-0 left-0 right-0 p-2">
+                                        <p className="text-xs text-white/90 text-center line-clamp-2">
+                                          {item.overview?.slice(0, 50)}...
+                                        </p>
+                                      </div>
+                                    </div>
                                   </div>
-                                </div>
-                              </div>
-                              <motion.h3 
-                                className="text-sm font-medium text-center text-white/80 line-clamp-1 group-hover:text-[#02c39a] transition-colors"
-                                initial={{ opacity: 0 }}
-                                animate={{ opacity: 1 }}
-                                transition={{ delay: 0.2 }}
-                              >
-                                {item.title || item.name}
-                              </motion.h3>
+                                  <motion.h3 
+                                    className="text-sm font-medium text-center text-white/80 line-clamp-1 group-hover:text-[#02c39a] transition-colors"
+                                    initial={{ opacity: 0 }}
+                                    animate={{ opacity: 1 }}
+                                    transition={{ delay: 0.2 }}
+                                  >
+                                    {item.title || item.name}
+                                  </motion.h3>
+                                </motion.div>
+                              ))}
                             </motion.div>
-                          ))}
-                        </motion.div>
-                      </div>
-                    </div>
+                          </div>
+                        </div>
+                      </motion.div>
+                    </Suspense>
                   </motion.div>
-                </Suspense>
-              </div>
+                )}
+              </AnimatePresence>
             </div>
-          </motion.div>
 
-          {/* Quick actions */}
-          <AnimatePresence>
-            {showQuickActions && (
-              <motion.div
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: 20 }}
-                className="fixed bottom-0 left-0 right-0 z-[60] p-3 sm:p-6 bg-gradient-to-t from-[#0a1118] to-transparent"
-              >
-                <QuickActions
-                  isInWatchlist={isInWatchlist}
-                  isInFavorites={isInFavorites}
-                  handleWatchlistToggle={handleWatchlistToggle}
-                  handleFavoritesToggle={handleFavoritesToggle}
-                  showQuickActions={showQuickActions}
-                />
-              </motion.div>
-            )}
-          </AnimatePresence>
-
-          {/* User lists button */}
-          <div className="fixed bottom-4 sm:bottom-6 left-2 sm:left-6 z-[60] flex flex-col gap-2">
-            <motion.button
-              onClick={() => setShowUserLists(true)}
-              whileHover={{ scale: 1.05 }}
-              whileTap={{ scale: 0.95 }}
-              className={`${buttonClasses.base} ${showUserLists
-                ? 'bg-[#c3022b] text-white hover:bg-[#a80016] dark:bg-[#ff0336] dark:hover:bg-[#d4002d]'
-                : isDarkMode ? 'bg-[#02c39a] text-white hover:bg-[#00a896] dark:bg-[#00edb8] dark:hover:bg-[#00c39a]'
-                  : `${lightModeStyles.buttonBg} ${lightModeStyles.buttonText}` } group relative xs:text-sm text-base sm:text-lg md:text-xl backdrop-blur-sm shadow-lg dark:shadow-black/50 w-full sm:w-auto`}
-              aria-label="Open user lists"
-            >
-              <div className="relative flex items-center justify-center">
-                <motion.svg
-                  animate={{ rotate: showUserLists ? 90 : 0 }}
-                  className="w-5 h-5 sm:w-6 sm:h-6"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
+            {/* Quick actions */}
+            <AnimatePresence>
+              {showQuickActions && !isDistractFree && (
+                <motion.div
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: 20 }}
+                  className="fixed bottom-0 left-0 right-0 z-[60] p-3 sm:p-6 bg-gradient-to-t from-[#0a1118] to-transparent"
                 >
-                  <path 
-                    strokeLinecap="round" 
-                    strokeLinejoin="round" 
-                    strokeWidth={2}
-                    d="M4 6h16M4 12h16M4 18h16" 
+                  <QuickActions
+                    isInWatchlist={isInWatchlist}
+                    isInFavorites={isInFavorites}
+                    handleWatchlistToggle={handleWatchlistToggle}
+                    handleFavoritesToggle={handleFavoritesToggle}
+                    showQuickActions={showQuickActions}
                   />
-                </motion.svg>
-                <span className="hidden sm:inline ml-2 whitespace-nowrap">
-                  My Lists
-                </span>
-              </div>
-            </motion.button>
-          </div>
+                </motion.div>
+              )}
+            </AnimatePresence>
 
-          {/* User lists overlay */}
-          <AnimatePresence>
-            {showUserLists && (
-              <motion.div
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                className="fixed inset-0 bg-black/70 backdrop-blur-sm z-[65]"
-                onClick={() => setShowUserLists(false)}
+            {/* User lists button */}
+            <AnimatePresence>
+              {!isDistractFree && (
+                <div className="fixed bottom-4 sm:bottom-6 left-2 sm:left-6 z-[60] flex flex-col gap-2">
+                  <motion.button
+                    onClick={() => setShowUserLists(true)}
+                    whileHover={{ scale: 1.05 }}
+                    whileTap={{ scale: 0.95 }}
+                    className={`${buttonClasses.base} ${showUserLists
+                      ? 'bg-[#c3022b] text-white hover:bg-[#a80016] dark:bg-[#ff0336] dark:hover:bg-[#d4002d]'
+                      : isDarkMode ? 'bg-[#02c39a] text-white hover:bg-[#00a896] dark:bg-[#00edb8] dark:hover:bg-[#00c39a]'
+                        : `${lightModeStyles.buttonBg} ${lightModeStyles.buttonText}` } group relative xs:text-sm text-base sm:text-lg md:text-xl backdrop-blur-sm shadow-lg dark:shadow-black/50 w-full sm:w-auto`}
+                    aria-label="Open user lists"
+                  >
+                    <div className="relative flex items-center justify-center">
+                      <motion.svg
+                        animate={{ rotate: showUserLists ? 90 : 0 }}
+                        className="w-5 h-5 sm:w-6 sm:h-6"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path 
+                          strokeLinecap="round" 
+                          strokeLinejoin="round" 
+                          strokeWidth={2}
+                          d="M4 6h16M4 12h16M4 18h16" 
+                        />
+                      </motion.svg>
+                      <span className="hidden sm:inline ml-2 whitespace-nowrap">
+                        My Lists
+                      </span>
+                    </div>
+                  </motion.button>
+                </div>
+              )}
+            </AnimatePresence>
+
+            {/* User lists overlay */}
+            <AnimatePresence>
+              {showUserLists && (
+                <motion.div
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  className="fixed inset-0 bg-black/70 backdrop-blur-sm z-[65]"
+                  onClick={() => setShowUserLists(false)}
+                />
+              )}
+            </AnimatePresence>
+
+            {/* User lists sidebar */}
+            <Suspense fallback={null}>
+              <UserListsSidebar
+                showUserLists={showUserLists}
+                setShowUserLists={setShowUserLists}
+                watchHistory={watchHistory}
+                watchlist={watchlist}
+                favorites={favorites}
+                handleListItemClick={handleListItemClick}
               />
-            )}
-          </AnimatePresence>
-
-          {/* User lists sidebar */}
-          <Suspense fallback={null}>
-            <UserListsSidebar
-              showUserLists={showUserLists}
-              setShowUserLists={setShowUserLists}
-              watchHistory={watchHistory}
-              watchlist={watchlist}
-              favorites={favorites}
-              handleListItemClick={handleListItemClick}
-            />
-          </Suspense>
+            </Suspense>
+          </motion.div>
         </ErrorBoundary>
       </div>
     </motion.div>

--- a/src/components/WatchPage.js
+++ b/src/components/WatchPage.js
@@ -432,6 +432,16 @@ const WatchPage = () => {
     return () => observer.disconnect();
   }, []);
 
+  const handleOrientationChange = () => {
+    setIsVideoReady(false);
+    setTimeout(() => setIsVideoReady(true), 100);
+  };
+
+  useEffect(() => {
+    window.addEventListener('orientationchange', handleOrientationChange);
+    return () => window.removeEventListener('orientationchange', handleOrientationChange);
+  }, []);
+
   const shouldShowBackgroundPoster = !isLowEndDevice && showBackgroundPoster;
 
   if (isLoading) {


### PR DESCRIPTION
# New Focus mode

> The distraction-free toggle is now added to the source selector area and will keep the following elements visible when enabled:
```
Video player
Source selector with video controls
Episode selection (for TV shows)
```

When you enter focus mode, everything else will smoothly fade out. You can test this by clicking the new "Focus Mode" button in the source selector area. The button shows a compact icon on mobile and includes text on larger screens.

- Making source selector controls stack vertically on mobile and horizontally on desktop
- Improving button layouts and spacing in the control area
- Adding proper truncation for long text in dropdowns and episode titles
- Making episode navigation adapt better to mobile screens with a column layout
- Optimizing the episode grid to show 2 columns on mobile, increasing gradually for larger screens
- Ensuring all interactive elements have proper touch targets for mobile users